### PR TITLE
feat: add support for 'make' command in Docker entrypoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,6 +173,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -49,6 +49,7 @@ for phpVersion in "${phpVersions[@]}"; do
         } > "$dir/Dockerfile"
 
         cp -aR templates "$dir/"
+        cp -aR bin "$dir/"
         cp -a cron-entrypoint.sh "$dir/"
         cp -a docker-entrypoint.sh "$dir/"
     done

--- a/bin/actions.mk
+++ b/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php7.2/apache/Dockerfile
+++ b/latest/php7.2/apache/Dockerfile
@@ -160,6 +160,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php7.2/apache/bin/actions.mk
+++ b/latest/php7.2/apache/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php7.2/apache/docker-entrypoint.sh
+++ b/latest/php7.2/apache/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php7.2/fpm/Dockerfile
+++ b/latest/php7.2/fpm/Dockerfile
@@ -157,6 +157,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php7.2/fpm/bin/actions.mk
+++ b/latest/php7.2/fpm/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php7.2/fpm/docker-entrypoint.sh
+++ b/latest/php7.2/fpm/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php7.3/apache/Dockerfile
+++ b/latest/php7.3/apache/Dockerfile
@@ -160,6 +160,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php7.3/apache/bin/actions.mk
+++ b/latest/php7.3/apache/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php7.3/apache/docker-entrypoint.sh
+++ b/latest/php7.3/apache/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php7.3/fpm/Dockerfile
+++ b/latest/php7.3/fpm/Dockerfile
@@ -157,6 +157,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php7.3/fpm/bin/actions.mk
+++ b/latest/php7.3/fpm/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php7.3/fpm/docker-entrypoint.sh
+++ b/latest/php7.3/fpm/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php7.4/apache/Dockerfile
+++ b/latest/php7.4/apache/Dockerfile
@@ -160,6 +160,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php7.4/apache/bin/actions.mk
+++ b/latest/php7.4/apache/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php7.4/apache/docker-entrypoint.sh
+++ b/latest/php7.4/apache/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php7.4/fpm/Dockerfile
+++ b/latest/php7.4/fpm/Dockerfile
@@ -157,6 +157,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php7.4/fpm/bin/actions.mk
+++ b/latest/php7.4/fpm/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php7.4/fpm/docker-entrypoint.sh
+++ b/latest/php7.4/fpm/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php8.0/apache/Dockerfile
+++ b/latest/php8.0/apache/Dockerfile
@@ -160,6 +160,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php8.0/apache/bin/actions.mk
+++ b/latest/php8.0/apache/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php8.0/apache/docker-entrypoint.sh
+++ b/latest/php8.0/apache/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php8.0/fpm/Dockerfile
+++ b/latest/php8.0/fpm/Dockerfile
@@ -157,6 +157,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php8.0/fpm/bin/actions.mk
+++ b/latest/php8.0/fpm/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php8.0/fpm/docker-entrypoint.sh
+++ b/latest/php8.0/fpm/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php8.1/apache/Dockerfile
+++ b/latest/php8.1/apache/Dockerfile
@@ -160,6 +160,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php8.1/apache/bin/actions.mk
+++ b/latest/php8.1/apache/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php8.1/apache/docker-entrypoint.sh
+++ b/latest/php8.1/apache/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php8.1/fpm/Dockerfile
+++ b/latest/php8.1/fpm/Dockerfile
@@ -157,6 +157,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php8.1/fpm/bin/actions.mk
+++ b/latest/php8.1/fpm/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php8.1/fpm/docker-entrypoint.sh
+++ b/latest/php8.1/fpm/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php8.2/apache/Dockerfile
+++ b/latest/php8.2/apache/Dockerfile
@@ -160,6 +160,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php8.2/apache/bin/actions.mk
+++ b/latest/php8.2/apache/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php8.2/apache/docker-entrypoint.sh
+++ b/latest/php8.2/apache/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php8.2/fpm/Dockerfile
+++ b/latest/php8.2/fpm/Dockerfile
@@ -157,6 +157,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php8.2/fpm/bin/actions.mk
+++ b/latest/php8.2/fpm/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php8.2/fpm/docker-entrypoint.sh
+++ b/latest/php8.2/fpm/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php8.3/apache/Dockerfile
+++ b/latest/php8.3/apache/Dockerfile
@@ -160,6 +160,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php8.3/apache/bin/actions.mk
+++ b/latest/php8.3/apache/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php8.3/apache/docker-entrypoint.sh
+++ b/latest/php8.3/apache/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi

--- a/latest/php8.3/fpm/Dockerfile
+++ b/latest/php8.3/fpm/Dockerfile
@@ -157,6 +157,7 @@ RUN set -eux; \
 COPY cron-entrypoint.sh /cron-entrypoint.sh
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
+COPY bin /usr/local/bin/
 
 USER inr
 WORKDIR ${APP_ROOT}

--- a/latest/php8.3/fpm/bin/actions.mk
+++ b/latest/php8.3/fpm/bin/actions.mk
@@ -1,0 +1,11 @@
+.PHONY: check-live
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Required parameter is missing: $1$(if $2, ($2))))
+
+check-live:
+	@echo "OK"

--- a/latest/php8.3/fpm/docker-entrypoint.sh
+++ b/latest/php8.3/fpm/docker-entrypoint.sh
@@ -35,4 +35,8 @@ process_templates
 
 exec_init_scripts
 
-exec /usr/local/bin/docker-php-entrypoint "${@}"
+if [[ "${1}" == "make" ]]; then
+    exec "${@}" -f /usr/local/bin/actions.mk
+else
+    exec /usr/local/bin/docker-php-entrypoint "${@}"
+fi


### PR DESCRIPTION
This pull request updates various Dockerfiles and entrypoint scripts to add a new bin directory containing additional scripts, and modifies the apply-templates.sh script to accommodate these changes.

- Added a new bin directory to Dockerfiles for additional scripts.
- Updated apply-templates.sh to copy the bin directory.
- Modified docker-entrypoint.sh to include logic for running the new scripts in bin.
- Added actions.mk files with a check-live target to the bin directory.
- Ensured Dockerfile configurations are aligned across different PHP versions (7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3).

These changes ensure a more standardized and maintainable approach to extending functionality within these containerized environments.